### PR TITLE
Suggest deactivating the default admin user instead of deleting.

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -32,7 +32,7 @@ When prompted to login use the default administrator credentials documented abov
 
 In the upper-right corner click "Add user". Type in the email address and name and click "Save". If you've already setup `Email <email.html>`_ then you will receive a registration email with an activation link. Ignore it. On the details page for your new user click the "change password form" link underneath the **Password** field. Enter your password and click "Change Password". Check the **Active**, **Staff status** and **Superuser status** checkboxes and click "Save".
 
-Log out and log back in with your new superuser. You may now delete the default administrator.
+Log out and log back in with your new superuser. You may now uncheck the **Active** checkbox for the default administrator and click "Save".
 
 Creating new PANDA users
 ========================


### PR DESCRIPTION
Deleting the default administrator via the admin requires deleting any items in the database related to the user, like documents and log entries. Deactivating is a decent equivalent.
