### PR TITLE
fix %20 routing issue in new firefox and chrome builds

### DIFF
--- a/client/static/js/routers/index.js
+++ b/client/static/js/routers/index.js
@@ -38,8 +38,15 @@ PANDA.routers.Index = Backbone.Router.extend({
          * in these Backbone tickets:
          * https://github.com/documentcloud/backbone/pull/1156
          * https://github.com/documentcloud/backbone/pull/1219
+         * As of 2013.02.21 it is also effecting Chrome
+         * changes made to work across browsers
+         * also fixes a related rendering error in the newest firefox
          */
+<<<<<<< HEAD
         if ($.browser.mozilla) {
+=======
+        if (param) {
+>>>>>>> 0998758... fix emerging %20 issues in chrome, firefox
             return param.replace("%20", " ");
         } else {
             return param;


### PR DESCRIPTION
In the most recent build Firefox is now having issues when there is no param value due to the lack of a null check in the previous code to address's firefox nonstandard handling of %20 values. Plus, Chrome is now incorporating whatever change was making Firefox behave badly in the first place.

So _ffix(param) is changed to simply test the existence of param and if it exists replace %20 with a space no matter the browser. This should be unnecessary, but isn't. It's probably wise to rename _ffix to something like _percent_20_fix, but I didn't want to muck around in case it's in use in multiple places.
