### PR TITLE
Add sorting to API

### DIFF
--- a/panda/api/data.py
+++ b/panda/api/data.py
@@ -541,6 +541,7 @@ class DataResource(PandaResource):
         since = request.GET.get('since', None)
         limit = int(request.GET.get('limit', settings.PANDA_DEFAULT_SEARCH_ROWS))
         offset = int(request.GET.get('offset', 0))
+        sort = request.GET.get('sort', '_docid_ asc')
 
         if query:
             solr_query = 'dataset_slug:%s AND (%s)' % (dataset.slug, query)
@@ -554,6 +555,7 @@ class DataResource(PandaResource):
             settings.SOLR_DATA_CORE,
             solr_query,
             offset=offset,
+            sort=sort,
             limit=limit
         )
 


### PR DESCRIPTION
I know this may blow up for large-ish datasets, but we'll be rolling it out along with a simple proxy for read-only API access so that we can use PANDA to drive editorial projects with data in the 1k - 50k row range.
