### PR TITLE
update wget command - prev URL was 404

### DIFF
--- a/docs/self-install.rst
+++ b/docs/self-install.rst
@@ -17,7 +17,7 @@ SSH into your server and run the following setup commands:
 
 .. code-block:: bash
 
-    wget https://raw.github.com/pandaproject/panda/1.1.2/setup_panda.sh
+    wget https://raw.githubusercontent.com/pandaproject/panda/master/setup_panda.sh
     sudo bash setup_panda.sh
 
 Note that the setup script **must** be run with sudo.


### PR DESCRIPTION
I was following the instructions for installation on http://panda.readthedocs.org/en/latest/self-install.html but the URL for `setup_panda.sh` returned a 404.

Here is a URL that works from the file on master branch